### PR TITLE
ci: add Python test WF with badge

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+
+  ############# External services
+
+  memcached:
+    image: memcached:1.4.38
+    restart: unless-stopped
+
+  mongodb:
+    image: mongo:4.0.26
+    # Use WiredTiger in all environments, just like at edx.org
+    command: mongod --smallfiles --nojournal --storageEngine wiredTiger
+    restart: unless-stopped
+
+  lms:
+    image: ghcr.io/eol-uchile/edx-platform:testing-eol-koa
+    volumes:
+      - ../:/openedx/requirements/app
+    depends_on:
+      - memcached
+      - mongodb

--- a/.github/test.sh
+++ b/.github/test.sh
@@ -1,0 +1,18 @@
+#!/bin/dash
+
+pip install -e /openedx/requirements/app
+
+if [ -f "/openedx/requirements/app/test_requirements.txt" ]; then
+    echo "Installing test requirements..."
+    pip install -r /openedx/requirements/app/test_requirements.txt
+fi
+
+cd /openedx/requirements/app
+cp /openedx/edx-platform/setup.cfg .
+mkdir test_root
+cd test_root/
+ln -s /openedx/staticfiles .
+
+cd /openedx/requirements/app
+
+DJANGO_SETTINGS_MODULE=lms.envs.test EDXAPP_TEST_MONGO_HOST=mongodb pytest

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -38,11 +38,7 @@ jobs:
           wget https://raw.githubusercontent.com/eol-uchile/workflow-commons/vastorga/add-python-test-badge/.github/test.sh -O wf_tmp/test.sh
           chmod +x wf_tmp/test.sh
           cd wf_tmp
-
-          docker compose run lms bash -c "cat > /tmp/test.sh << 'EOF' && chmod +x /tmp/test.sh && /tmp/test.sh
-          $(cat test.sh)
-          EOF"
-#          docker compose run lms /openedx/requirements/app/wf_tmp/test.sh
+          docker compose run lms /openedx/requirements/app/wf_tmp/test.sh
 
       - name: Clean Tests
         run: |

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,0 +1,68 @@
+name: Test Python with badge
+
+on:
+  workflow_call:
+    secrets:
+      private_key:
+        required: true
+    inputs:
+      app_id:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: 
+    steps:
+      - name: Create GitHub App Token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ inputs.app_id}}
+          private-key: ${{ secrets.private_key }}
+          owner: eol-uchile
+          repository: workflow-commons
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: 'recursive'
+          token: ${{ steps.app_token.outputs.token }}
+
+      - name: Run Tests
+        run: |
+          mkdir wf_tmp
+          wget https://raw.githubusercontent.com/eol-uchile/workflow-commons/vastorga/add-python-test-badge/.github/docker-compose.yml -O wf_tmp/docker-compose.yml 
+          wget https://raw.githubusercontent.com/eol-uchile/workflow-commons/vastorga/add-python-test-badge/.github/test.sh -O wf_tmp/test.sh
+          chmod +x wf_tmp/test.sh
+          cd wf_tmp
+
+          docker compose run lms bash -c "cat > /tmp/test.sh << 'EOF' && chmod +x /tmp/test.sh && /tmp/test.sh
+          $(cat test.sh)
+          EOF"
+#          docker compose run lms /openedx/requirements/app/wf_tmp/test.sh
+
+      - name: Clean Tests
+        run: |
+          cd wf_tmp/
+          docker compose down
+          cd ..
+          rm -Rf wf_tmp/
+
+      - name: Configure Git
+        run: |
+          git config user.name "eolito[bot]"
+          git config user.email "217098583+eolito[bot]@users.noreply.github.com"
+
+      - name: Commit badge if changed
+        run: |
+          if [ "$(git status --porcelain coverage-badge.svg)" != "" ]
+          then
+            git add coverage-badge.svg
+            git commit -m "chore: Auto-generate coverage badge"
+            git push
+          else
+            echo "No changes to coverage badge. Skipping commit step."
+          fi


### PR DESCRIPTION
- Implements a reusable workflow that runs Python tests and auto-commits an updated coverage badge when it changes.