### PR TITLE
feat(pythonapp): adds support for environments

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,6 +8,9 @@ on:
       private_key:
         required: false
     inputs:
+      environment:
+        required: false
+        type: string
       app_id:
         required: false
         type: string
@@ -32,6 +35,7 @@ jobs:
   tests:
     needs: [ variables ]
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     env:
       RELEASE-NAME: ${{ needs.variables.outputs.release-name }}
     name: 
@@ -58,6 +62,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 1
           submodules: 'recursive'
           token: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
#### Actualización de pythonapp.yml (`workflow-commons`)

Se actualiza la configuración del checkout para que GH descargue el código del PR fork y no el original. Esto debido a que `pull_request_target` corre en el contexto del repositorio original por seguridad

#### Environment en cada repo (ej. `eol-container-xblock`)

Se reemplaza `pull_request` por `pull_request_target` en el repositorio base, ya que usando `pull_request` el workflow no puede tener acceso a secrets y vars en un PR externo (forks)

Al usar `pull_request_target` se abre una brecha de seguridad, si el WF tiene acceso a los secretos de forma automática, un atacante podría mandar PR y robar datos sin darnos cuenta. El Environment actúa como una barrera solicitando revisión manual y pausando el workflow antes de ejecutar

Se configura el `Environment`, definiendo:

- `Required reviewers` (usuarios autorizados)
- Environment Variables: `EOLITO_BOT_APP_ID`
- Environment Secrets: `EOLITO_BOT_PRIVATE_KEY`
 
[Prueba de funcionamiento](https://github.com/eol-uchile/eol-container-xblock/actions/runs/23313122878). Recordar que se usa el WF de la rama default, que para las pruebas fue [este](https://github.com/eol-uchile/eol-container-xblock/blob/eol/koa/.github/workflows/pythonapp.yml)

#### Importante

Para que GH empiece a atajar y ejecutar los PRs que vienen de forks, `pull_request_target` debe existir en la rama default del repo. GH ignora el evento pull_request_target si este solo existe en ramas secundarias o el propio PR